### PR TITLE
feat: make Groq primary AI provider with OpenAI fallback

### DIFF
--- a/app/api/ai/analyze/route.ts
+++ b/app/api/ai/analyze/route.ts
@@ -1,7 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-// Gemini (commented out - using OpenAI instead)
-// import { GoogleGenerativeAI } from '@google/generative-ai'
-import OpenAI from 'openai'
+import { callAIChatCompletion, isAIConfigured } from '@/lib/ai/client'
 import { CreditsService, AIFeature } from '@/lib/services/credits'
 
 interface PersonalInfo {
@@ -368,54 +366,28 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const apiKey = process.env.OPENAI_API_KEY
-
-    if (!apiKey) {
+    if (!isAIConfigured()) {
       const fallbackAnalysis = getFallbackAnalysis(resumeData)
-
-      return NextResponse.json({
-        analysis: fallbackAnalysis,
-        success: true,
-        fallback: true
-      })
+      return NextResponse.json({ analysis: fallbackAnalysis, success: true, fallback: true })
     }
 
     try {
-      // Gemini (commented out - using OpenAI instead)
-      // const genAI = new GoogleGenerativeAI(apiKey)
-      // const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' })
-      // const result = await model.generateContent(prompt)
-      // const response = await result.response
-      // const text = response.text()
-
-      // OpenAI Implementation
-      const openai = new OpenAI({ apiKey })
       const prompt = getAnalysisPrompt(resumeData)
 
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
+      const text = await callAIChatCompletion(
+        [
           {
             role: 'system',
             content: 'You are an expert resume analyst. Analyze resumes and provide detailed, constructive feedback in valid JSON format only.'
           },
-          {
-            role: 'user',
-            content: prompt
-          }
+          { role: 'user', content: prompt }
         ],
-        max_tokens: 2000,
-        temperature: 0.7,
-      })
+        { max_tokens: 2000, temperature: 0.7 }
+      )
 
-      const text = completion.choices[0]?.message?.content || ''
-
-      // Parse JSON response
       let analysisResult: AnalysisResult
       try {
-        // Clean the response text of any markdown formatting
-        const cleanText = text.replace(/```json\n?/g, '').replace(/```\n?/g, '').trim()
-
+        const cleanText = (text ?? '').replace(/```json\n?/g, '').replace(/```\n?/g, '').trim()
         analysisResult = JSON.parse(cleanText)
       } catch (_parseError) {
         throw new Error('Failed to parse AI analysis response - Invalid JSON format')
@@ -430,7 +402,6 @@ export async function POST(request: NextRequest) {
 
     } catch (_aiError) {
       const fallbackAnalysis = getFallbackAnalysis(resumeData)
-
       return NextResponse.json({
         analysis: fallbackAnalysis,
         success: true,

--- a/app/api/ai/generate-from-job/route.ts
+++ b/app/api/ai/generate-from-job/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-import OpenAI from 'openai'
+import { callAIChatCompletion, isAIConfigured } from '@/lib/ai/client'
 import { aiLimiter, getClientIP, createRateLimitResponse, addRateLimitHeaders } from '@/lib/security/rate-limiter'
 import { logger, requestTracker, generateRequestId } from '@/lib/utils/monitoring'
 import { CreditsService } from '@/lib/services/credits'
@@ -228,19 +228,16 @@ export async function POST(request: NextRequest) {
       )
     }
 
-    const apiKey = process.env.OPENAI_API_KEY
-    if (!apiKey) {
+    if (!isAIConfigured()) {
       requestTracker.end(requestId, 503)
       return NextResponse.json({ error: 'AI service is not configured.' }, { status: 503 })
     }
 
     try {
-      const openai = new OpenAI({ apiKey })
       const prompt = buildPrompt(jobPost.trim(), baseResume)
 
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
+      const rawJson = await callAIChatCompletion(
+        [
           {
             role: 'system',
             content:
@@ -248,18 +245,19 @@ export async function POST(request: NextRequest) {
           },
           { role: 'user', content: prompt },
         ],
-        max_tokens: 2500,
-        temperature: 0.7,
-        response_format: { type: 'json_object' },
-      })
+        { max_tokens: 2500, temperature: 0.7, response_format: { type: 'json_object' } }
+      )
 
-      const rawJson = completion.choices[0]?.message?.content || '{}'
+      if (!rawJson) {
+        requestTracker.end(requestId, 500)
+        return NextResponse.json({ error: 'AI generation failed. Please try again.' }, { status: 500 })
+      }
+
       let parsedData: any
-
       try {
         parsedData = JSON.parse(rawJson)
       } catch {
-        logger.error('Failed to parse OpenAI JSON response', { requestId })
+        logger.error('Failed to parse AI JSON response', { requestId })
         requestTracker.end(requestId, 500)
         return NextResponse.json(
           { error: 'Failed to parse AI response. Please try again.' },
@@ -277,7 +275,7 @@ export async function POST(request: NextRequest) {
       requestTracker.end(requestId, 200)
       return addRateLimitHeaders(response, rateLimit.remaining, rateLimit.resetTime, 10)
     } catch (aiError) {
-      logger.error('OpenAI call failed in generate-from-job', {
+      logger.error('AI call failed in generate-from-job', {
         error: aiError instanceof Error ? aiError.message : String(aiError),
       })
       requestTracker.end(requestId, 500)

--- a/app/api/ai/parse-resume/route.ts
+++ b/app/api/ai/parse-resume/route.ts
@@ -1,10 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server'
-// Gemini (commented out - using OpenAI instead)
-// import { GoogleGenerativeAI } from '@google/generative-ai'
-import OpenAI from 'openai'
-
-// Gemini (commented out - using OpenAI instead)
-// const genAI = new GoogleGenerativeAI(process.env.GEMINI_API_KEY || '')
+import { callAIChatCompletion, isAIConfigured } from '@/lib/ai/client'
 
 // Function to safely import pdf-parse
 const parsePDF = async (buffer: Buffer): Promise<string> => {
@@ -279,11 +274,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Parse with AI
-    // Gemini (commented out - using OpenAI instead)
-    // const apiKey = process.env.GEMINI_API_KEY
-    const apiKey = process.env.OPENAI_API_KEY
-    
-    if (!apiKey) {
+    if (!isAIConfigured()) {
       return NextResponse.json(
         { error: 'AI parsing service is not configured.', success: false },
         { status: 500 }
@@ -291,34 +282,18 @@ export async function POST(request: NextRequest) {
     }
 
     try {
-      // Gemini (commented out - using OpenAI instead)
-      // const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' })
-      // const prompt = getParsingPrompt(extractedText)
-      // const result = await model.generateContent(prompt)
-      // const response = await result.response
-      // const text = response.text()
-
-      // OpenAI Implementation
-      const openai = new OpenAI({ apiKey })
       const prompt = getParsingPrompt(extractedText)
-      
-      const completion = await openai.chat.completions.create({
-        model: 'gpt-4o-mini',
-        messages: [
+
+      const text = await callAIChatCompletion(
+        [
           {
             role: 'system',
             content: 'You are a resume parsing expert. Extract structured information from resumes and return valid JSON only. Preserve proper spacing and formatting in extracted text.'
           },
-          {
-            role: 'user',
-            content: prompt
-          }
+          { role: 'user', content: prompt }
         ],
-        max_tokens: 2000,
-        temperature: 0.3, // Lower temperature for more consistent parsing
-      })
-      
-      const text = completion.choices[0]?.message?.content || ''
+        { max_tokens: 2000, temperature: 0.3 }
+      ) ?? ''
 
       // Parse JSON response
       let parsedData: ParsedResumeData

--- a/lib/ai/client.ts
+++ b/lib/ai/client.ts
@@ -20,7 +20,7 @@ export function isAIConfigured(): boolean {
 }
 
 /**
- * Calls OpenAI chat completions, falling back to Groq if OpenAI fails or is unconfigured.
+ * Calls Groq API first (primary), falling back to OpenAI if Groq fails or is unavailable.
  * Returns null only if both providers are unconfigured or both fail.
  */
 export async function callAIChatCompletion(
@@ -30,28 +30,28 @@ export async function callAIChatCompletion(
   const openaiKey = process.env.OPENAI_API_KEY
   const groqKey = process.env.GROQ_API_KEY
 
-  if (openaiKey) {
+  if (groqKey) {
     try {
-      const client = new OpenAI({ apiKey: openaiKey })
+      const client = new OpenAI({ apiKey: groqKey, baseURL: GROQ_BASE_URL })
       const completion = await client.chat.completions.create({
-        model: OPENAI_MODEL,
+        model: GROQ_MODEL,
         messages,
         ...options,
       })
       return completion.choices[0]?.message?.content ?? null
     } catch (err) {
-      if (!groqKey) throw err
+      if (!openaiKey) throw err
       console.warn(
-        '[AI] OpenAI failed, falling back to Groq:',
+        '[AI] Groq failed, falling back to OpenAI:',
         err instanceof Error ? err.message : String(err)
       )
     }
   }
 
-  if (groqKey) {
-    const client = new OpenAI({ apiKey: groqKey, baseURL: GROQ_BASE_URL })
+  if (openaiKey) {
+    const client = new OpenAI({ apiKey: openaiKey })
     const completion = await client.chat.completions.create({
-      model: GROQ_MODEL,
+      model: OPENAI_MODEL,
       messages,
       ...options,
     })

--- a/lib/ai/config.ts
+++ b/lib/ai/config.ts
@@ -11,16 +11,16 @@ export const AI_CONFIG = {
 
   isConfigured: () => Boolean(process.env.OPENAI_API_KEY || process.env.GROQ_API_KEY),
   getProvider: () => {
-    if (process.env.OPENAI_API_KEY) return 'OpenAI'
     if (process.env.GROQ_API_KEY) return 'Groq'
+    if (process.env.OPENAI_API_KEY) return 'OpenAI'
     return 'None'
   },
   getStatus: () => {
-    if (process.env.OPENAI_API_KEY) {
-      return { configured: true, message: 'AI features enabled with OpenAI' }
-    }
     if (process.env.GROQ_API_KEY) {
-      return { configured: true, message: 'AI features enabled with Groq (fallback)' }
+      return { configured: true, message: 'AI features enabled with Groq' }
+    }
+    if (process.env.OPENAI_API_KEY) {
+      return { configured: true, message: 'AI features enabled with OpenAI (fallback)' }
     }
     return {
       configured: false,


### PR DESCRIPTION
- Update lib/ai/client.ts to try Groq first, fallback to OpenAI
- Update lib/ai/config.ts status messages to reflect Groq as primary
- Refactor AI routes (analyze, generate-from-job, parse-resume) to use callAIChatCompletion helper instead of direct OpenAI calls
- Remove redundant Gemini/OpenAI imports from route files